### PR TITLE
fix: resolve line chart and pie chart ResponsiveContainer issues

### DIFF
--- a/src/artifacts/interactive-dashboard.tsx
+++ b/src/artifacts/interactive-dashboard.tsx
@@ -133,22 +133,20 @@ export default function InteractiveDashboard() {
               <CardDescription>Growth percentage over time</CardDescription>
             </CardHeader>
             <CardContent>
-              <div style={{ width: '100%', height: '300px' }}>
-                <ResponsiveContainer>
-                  <LineChart data={sampleData}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="name" />
-                    <YAxis />
-                    <Tooltip />
-                    <Line 
-                      dataKey="growth" 
-                      stroke="#82ca9d" 
-                      strokeWidth={2}
-                      dot={{ r: 4 }}
-                    />
-                  </LineChart>
-                </ResponsiveContainer>
-              </div>
+              <ResponsiveContainer width="100%" height={300}>
+                <LineChart data={sampleData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="name" />
+                  <YAxis />
+                  <Tooltip />
+                  <Line 
+                    dataKey="growth" 
+                    stroke="#82ca9d" 
+                    strokeWidth={2}
+                    dot={{ r: 4 }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
             </CardContent>
           </Card>
         </TabsContent>
@@ -160,25 +158,23 @@ export default function InteractiveDashboard() {
               <CardDescription>Framework usage across projects</CardDescription>
             </CardHeader>
             <CardContent>
-              <div style={{ width: '100%', height: '350px' }}>
-                <ResponsiveContainer>
-                  <PieChart>
-                    <Pie
-                      data={pieData}
-                      cx="50%"
-                      cy="50%"
-                      outerRadius={80}
-                      dataKey="value"
-                    >
-                      {pieData.map((entry, index) => (
-                        <Cell key={`cell-${index}`} fill={entry.color} />
-                      ))}
-                    </Pie>
-                    <Tooltip />
-                    <Legend />
-                  </PieChart>
-                </ResponsiveContainer>
-              </div>
+              <ResponsiveContainer width="100%" height={350}>
+                <PieChart>
+                  <Pie
+                    data={pieData}
+                    cx="50%"
+                    cy="50%"
+                    outerRadius={100}
+                    dataKey="value"
+                  >
+                    {pieData.map((entry, index) => (
+                      <Cell key={`cell-${index}`} fill={entry.color} />
+                    ))}
+                  </Pie>
+                  <Tooltip />
+                  <Legend />
+                </PieChart>
+              </ResponsiveContainer>
             </CardContent>
           </Card>
         </TabsContent>


### PR DESCRIPTION
Fixes ##2

## Summary
- Remove unnecessary div wrappers causing sizing conflicts
- Use proper ResponsiveContainer with explicit dimensions
- Increase pie chart outerRadius from 80 to 100 for better visibility

## Test plan
- [ ] Verify line chart renders correctly without sizing issues
- [ ] Verify pie chart renders correctly with improved visibility
- [ ] Test responsive behavior across different screen sizes
- [ ] Run Playwright tests to confirm issues are resolved

Generated with [Claude Code](https://claude.ai/code)